### PR TITLE
ex: avoid repetition repetition

### DIFF
--- a/modules/ex/src/clj/exoscale/ex.clj
+++ b/modules/ex/src/clj/exoscale/ex.clj
@@ -268,7 +268,8 @@
   :args (s/cat :spec qualified-keyword?
                :x any?
                :data (s/? (s/nilable ::ex-data))))
-(defn ex-invalid-spec
+
+(defn invalid-spec
   "Returns an ex-info when value `x` does not conform to spec `spex`"
   ([spec x]
    (ex-invalid-spec spec x nil))
@@ -276,3 +277,7 @@
    (exoscale.ex/ex-info (format "Invalid spec: %s" (s/explain-str spec x))
                         [::invalid-spec [::incorrect]]
                         (assoc data :explain-data (s/explain-data spec x)))))
+
+(def ex-invalid-spec
+  "See `invalid-spec`"
+  #'invalid-spec)


### PR DESCRIPTION
With ex usually required with an `:as ex` prefix, it feels
nicer to call `(throw (ex/invalid-spec ::spec val))`

The previous symbol is preserved for now