### PR TITLE
add 2 way datafy <-> map coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,24 @@ We have a few helpers
    ```
    It dispatches via `try+/catch`, so relations are supported.
 
+* we support turning these kind of ex-infos into data via `clojure.core.protocols/datafy`
+  and back into exceptions via `exoscale.ex/map->ex-info`.
+
+
+
+```clj
+=> (clojure.core.protocols/datafy (ex/ex-incorrect "boom" {:a 1} (ex/ex-incorrect "the-cause")))
+#:exoscale.ex{:type :exoscale.ex/incorrect
+               :message "boom"
+               :data {:a 1, :type :exoscale.ex/incorrect}
+               :deriving #{:exoscale.ex/foo :exoscale.ex/bar}
+               :cause #:exoscale.ex{:type :exoscale.ex/incorrect
+                                    :message "the-cause"
+                                    :data {:type :exoscale.ex/incorrect}
+                                    :deriving #{:exoscale.ex/foo :exoscale.ex/bar}}
+
+```
+
 ## Usage examples
 
 Some real life examples of usage for this:

--- a/README.md
+++ b/README.md
@@ -264,13 +264,13 @@ We have a few helpers
 ```clj
 => (clojure.core.protocols/datafy (ex/ex-incorrect "boom" {:a 1} (ex/ex-incorrect "the-cause")))
 #:exoscale.ex{:type :exoscale.ex/incorrect
-               :message "boom"
-               :data {:a 1, :type :exoscale.ex/incorrect}
-               :deriving #{:exoscale.ex/foo :exoscale.ex/bar}
-               :cause #:exoscale.ex{:type :exoscale.ex/incorrect
-                                    :message "the-cause"
-                                    :data {:type :exoscale.ex/incorrect}
-                                    :deriving #{:exoscale.ex/foo :exoscale.ex/bar}}
+              :message "boom"
+              :data {:a 1, :type :exoscale.ex/incorrect}
+              :deriving #{:exoscale.ex/foo :exoscale.ex/bar}
+              :cause #:exoscale.ex{:type :exoscale.ex/incorrect
+                                   :message "the-cause"
+                                   :data {:type :exoscale.ex/incorrect}
+                                   :deriving #{:exoscale.ex/foo :exoscale.ex/bar}}
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ We have a few helpers
                                    :data {:type :exoscale.ex/incorrect}
                                    :deriving #{:exoscale.ex/foo :exoscale.ex/bar}}
 
+=> (type (ex/map->ex-info *1))
+clojure.lang.ExceptionInfo
+
 ```
 
 ## Usage examples

--- a/modules/ex/test/exoscale/ex/test/core_test.clj
+++ b/modules/ex/test/exoscale/ex/test/core_test.clj
@@ -139,20 +139,32 @@
 
 (deftest datafy
   (let  [x (ex/ex-info "boom"
-                       [::ex/incorrect [::ex/foo ::ex/bar]]
+                       [::datafy [::ex/foo ::ex/bar]]
                        {:a 1}
                        (ex/ex-incorrect "the-cause"))]
     (is (= (p/datafy x)
-           #:exoscale.ex{:type :exoscale.ex/incorrect
+           #:exoscale.ex{:type ::datafy
                          :message "boom"
-                         :data {:a 1, :type :exoscale.ex/incorrect}
+                         :data {:a 1, :type ::datafy}
                          :deriving #{:exoscale.ex/foo :exoscale.ex/bar}
-                         :cause #:exoscale.ex{:type :exoscale.ex/incorrect
+                         :cause #:exoscale.ex{:type ::ex/incorrect
                                               :message "the-cause"
-                                              :data {:type :exoscale.ex/incorrect}
-                                              :deriving #{:exoscale.ex/foo :exoscale.ex/bar}}})
+                                              :data {:type ::ex/incorrect}}})
         "test datafy in")
     (is (= (p/datafy x) (p/datafy (ex/map->ex-info (p/datafy x) {::ex/derive? true})))
         "test roundtrip")
     (is (= (p/datafy x) (p/datafy (ex/map->ex-info (dissoc (p/datafy x) ::ex/deriving))))
-        "test roundtrip without derivation")))
+        "test roundtrip without derivation"))
+
+  (let  [x (ex/ex-incorrect "boom")]
+    (is (= (p/datafy x)
+           #:exoscale.ex{:type :exoscale.ex/incorrect
+                         :message "boom"
+                         :data {:type :exoscale.ex/incorrect}})
+        "test datafy in")
+    (is (= (p/datafy x) (p/datafy (ex/map->ex-info (dissoc (p/datafy x) ::ex/deriving))))
+        "test roundtrip without derivation"))
+
+  (let  [x (clojure.core/ex-info "boom" {})]
+    (is (false? (s/valid? (p/datafy x) ::ex/ex-map))
+        "regular ex info is passthrough")))

--- a/modules/ex/test/exoscale/ex/test/core_test.clj
+++ b/modules/ex/test/exoscale/ex/test/core_test.clj
@@ -4,7 +4,8 @@
    [exoscale.ex :as ex]
    [exoscale.ex.test :as t]
    [clojure.spec.alpha :as s]
-   [clojure.spec.test.alpha]))
+   [clojure.spec.test.alpha]
+   [clojure.core.protocols :as p]))
 
 (clojure.spec.test.alpha/instrument)
 
@@ -135,3 +136,23 @@
 
   (is (not (ex/type? (ex/ex-info "bar" [::fx [::xx]])
                      ::xxy))))
+
+(deftest datafy
+  (let  [x (ex/ex-info "boom"
+                       [::ex/incorrect [::ex/foo ::ex/bar]]
+                       {:a 1}
+                       (ex/ex-incorrect "the-cause"))]
+    (is (= (p/datafy x)
+           #:exoscale.ex{:type :exoscale.ex/incorrect
+                         :message "boom"
+                         :data {:a 1, :type :exoscale.ex/incorrect}
+                         :deriving #{:exoscale.ex/foo :exoscale.ex/bar}
+                         :cause #:exoscale.ex{:type :exoscale.ex/incorrect
+                                              :message "the-cause"
+                                              :data {:type :exoscale.ex/incorrect}
+                                              :deriving #{:exoscale.ex/foo :exoscale.ex/bar}}})
+        "test datafy in")
+    (is (= (p/datafy x) (p/datafy (ex/map->ex-info (p/datafy x) {::ex/derive? true})))
+        "test roundtrip")
+    (is (= (p/datafy x) (p/datafy (ex/map->ex-info (dissoc (p/datafy x) ::ex/deriving))))
+        "test roundtrip without derivation")))


### PR DESCRIPTION
This allows to return a map representing exoscale.ex ex-infos via
`clojure.core/datafy` and turn this map back into an ex-info via
`exoscale.ex/map->ex-info`. 

the returned map looks like this: 

```clj
 #:exoscale.ex{:type :exoscale.ex/incorrect
               :message "boom"
               :data {:a 1, :type :exoscale.ex/incorrect}
               :deriving #{:exoscale.ex/foo :exoscale.ex/bar}
               :cause #:exoscale.ex{:type :exoscale.ex/incorrect
                                    :message "the-cause"
                                    :data {:type :exoscale.ex/incorrect}
                                    :deriving #{:exoscale.ex/foo :exoscale.ex/bar}}
```
calling map->ex-info on it turns it back into an ex-info we can just throw: 

```clj
#error {
 :cause "the-cause"
 :data {:type :exoscale.ex/incorrect}
 :via
 [{:type clojure.lang.ExceptionInfo
   :message "boom"
   :data {:a 1, :type :exoscale.ex/incorrect}
   :at [exoscale.ex$ex_info invokeStatic "ex.clj" 248]}
  {:type clojure.lang.ExceptionInfo
   :message "the-cause"
   :data {:type :exoscale.ex/incorrect}
   :at [exoscale.ex$ex_info invokeStatic "ex.clj" 248]}]
 :trace [...]}
```

