### PR TITLE
enhance datafy

### DIFF
--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -334,7 +334,7 @@
               deriving (parents type)]
           (cond-> {::type type
                    ::message (ex-message x)
-                   ::data data}
+                   ::data (dissoc data :type)}
             (seq deriving)
             (assoc ::deriving deriving)
             (some? cause)

--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -325,6 +325,8 @@
                 ::data]
           :opt [::deriving
                 ::cause]))
+(s/def ::cause ::ex-map)
+
 (extend-protocol p/Datafiable
   clojure.lang.ExceptionInfo
   (datafy [x]

--- a/modules/ex/test/exoscale/ex/test/core_test.clj
+++ b/modules/ex/test/exoscale/ex/test/core_test.clj
@@ -145,11 +145,11 @@
     (is (= (p/datafy x)
            #:exoscale.ex{:type ::datafy
                          :message "boom"
-                         :data {:a 1, :type ::datafy}
+                         :data {:a 1}
                          :deriving #{:exoscale.ex/foo :exoscale.ex/bar}
                          :cause #:exoscale.ex{:type ::ex/incorrect
                                               :message "the-cause"
-                                              :data {:type ::ex/incorrect}}})
+                                              :data {}}})
         "test datafy in")
     (is (= (p/datafy x) (p/datafy (ex/map->ex-info (p/datafy x) {::ex/derive? true})))
         "test roundtrip")
@@ -160,7 +160,7 @@
     (is (= (p/datafy x)
            #:exoscale.ex{:type :exoscale.ex/incorrect
                          :message "boom"
-                         :data {:type :exoscale.ex/incorrect}})
+                         :data {}})
         "test datafy in")
     (is (= (p/datafy x) (p/datafy (ex/map->ex-info (dissoc (p/datafy x) ::ex/deriving))))
         "test roundtrip without derivation"))


### PR DESCRIPTION
without this when we serialize exes we need to make sure we do not have diffs after coercion (ex.type and ex.data.type could differ). 

so add spec for exo.ex/cause + remove ex-data.type from serialized ex-info  since it's already present as top level key.