### PR TITLE
feat(http): Add utility to map http responses to typed exceptions

### DIFF
--- a/modules/ex-http/project.clj
+++ b/modules/ex-http/project.clj
@@ -1,0 +1,14 @@
+(defproject exoscale/ex-http "0.3.12-SNAPSHOT"
+  :plugins [[lein-parent "0.3.8"]]
+  :parent-project {:path "../../project.clj"
+                   :inherit [:managed-dependencies
+                             :license
+                             :url
+                             :scm
+                             :deploy-repositories
+                             :profiles
+                             :description
+                             :pedantic?]}
+  :source-paths ["src/clj"]
+  :dependencies [[org.clojure/clojure]
+                 [exoscale/ex]])

--- a/modules/ex-http/src/clj/exoscale/ex/http.clj
+++ b/modules/ex-http/src/clj/exoscale/ex/http.clj
@@ -1,0 +1,60 @@
+(ns exoscale.ex.http
+  (:require [exoscale.ex :as ex]))
+
+(defmulti response->ex-info
+  "Throws the matching ex exception for status HTTP response.
+  Clients are expected to have already handled success status codes."
+  :status)
+
+(defmethod response->ex-info
+  :default
+  [resp] (ex/ex-fault! "HTTP Error" {:response resp}))
+
+(defmethod response->ex-info
+  404
+  [resp] (ex/ex-not-found! "Not Found" {:response resp}))
+
+(defmethod response->ex-info
+  403
+  [resp] (ex/ex-forbidden! "Forbidden" {:response resp}))
+
+(defmethod response->ex-info
+  401
+  [resp] (ex/ex-forbidden! "Unauthorized" {:response resp}))
+
+(defmethod response->ex-info
+  400
+  [resp] (ex/ex-incorrect! "Bad Request" {:response resp}))
+
+(defmethod response->ex-info
+  409
+  [resp] (ex/ex-conflict! "Conflict" {:response resp}))
+
+(defmethod response->ex-info
+  405
+  [resp] (ex/ex-unsupported! "Method Not Allowed" {:response resp}))
+
+(defmethod response->ex-info
+  429
+  [resp] (ex/ex-busy! "Too Many Requests" {:response resp}))
+
+(defmethod response->ex-info
+  500
+  [resp] (ex/ex-fault! "Internal Server Error" {:response resp}))
+
+(defmethod response->ex-info
+  501
+  [resp] (ex/ex-unsupported! "Not Implemented" {:response resp}))
+
+(defmethod response->ex-info
+  503
+  [resp] (ex/ex-busy! "Service Unavailable" {:response resp}))
+
+(defmethod response->ex-info
+  502
+  [resp] (ex/ex-unavailable! "Bad Gateway" {:response resp}))
+
+(defmethod response->ex-info
+  504
+  [resp] (ex/ex-unavailable! "Gateway Timeout" {:response resp}))
+

--- a/modules/ex-http/test/exoscale/ex/test/http_test.clj
+++ b/modules/ex-http/test/exoscale/ex/test/http_test.clj
@@ -1,0 +1,42 @@
+(ns exoscale.ex.test.http-test
+  (:require
+   [clojure.test :refer [deftest testing is] :as t]
+   [exoscale.ex :as ex]
+   [exoscale.ex.http :as ex-http]))
+
+(defmethod t/assert-expr 'thrown-ex-info-type? [msg form]
+  ;; (is (thrown-ex-data? c expr))
+  ;; Asserts that evaluating expr throws an exceptioninfo of :type `k`.
+  ;; Returns the exceptioninfo thrown.
+  (let [k (nth form 1)
+        body (nthnext form 2)]
+    `(ex/try+
+      ~@body
+      (t/do-report {:type :fail
+                    :message ~msg
+                    :expected '~form
+                    :actual nil})
+      (catch ~k d#
+        (t/do-report {:type :pass
+                      :message ~msg,
+                      :expected '~form
+                      :actual d#})
+        (::ex/exception d#))
+      (catch Exception e#
+        (t/do-report {:type :fail
+                      :message ~msg
+                      :expected '~form
+                      :actual e#})))))
+
+(deftest response->ex-info
+  (testing "Should return ex/fault as the default option"
+    (is (thrown-ex-info-type? ::ex/fault (ex-http/response->ex-info {:status :not-mapped}))))
+
+  (testing "Should return ex/not-found for a 404"
+    (is (thrown-ex-info-type? ::ex/not-found (ex-http/response->ex-info {:status 404}))))
+
+  (testing "Should allow overwriting in a consuming namespace"
+    (do (defmethod ex-http/response->ex-info 404 [_] ::overwritten)
+        (is (= ::overwritten
+               (ex-http/response->ex-info {:status 404}))))))
+

--- a/project.clj
+++ b/project.clj
@@ -14,13 +14,15 @@
                          [cc.qbits/auspex      "0.1.0-alpha2"]
                          [exoscale/ex          :version]
                          [exoscale/ex-manifold :version]
-                         [exoscale/ex-auspex   :version]]
+                         [exoscale/ex-auspex   :version]
+                         [exoscale/ex-http     :version]]
 
   :profiles {:dev {:plugins [[lein-cljfmt "0.6.7"]]}}
 
   :sub ["modules/ex"
         "modules/ex-manifold"
-        "modules/ex-auspex"]
+        "modules/ex-auspex"
+        "modules/ex-http"]
 
   :release-tasks [["vcs" "assert-committed"]
                   ["sub" "change" "version" "leiningen.release/bump-version" "release"]


### PR DESCRIPTION
Let me know if you agree with the mappings, or if you'd like to add more to the default mappings.