### PR TITLE
fix(http): Add bang to response->ex-info to signal that it throws

### DIFF
--- a/modules/ex-http/src/clj/exoscale/ex/http.clj
+++ b/modules/ex-http/src/clj/exoscale/ex/http.clj
@@ -1,60 +1,60 @@
 (ns exoscale.ex.http
   (:require [exoscale.ex :as ex]))
 
-(defmulti response->ex-info
+(defmulti response->ex-info!
   "Throws the matching ex exception for status HTTP response.
   Clients are expected to have already handled success status codes."
   :status)
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   :default
   [resp] (ex/ex-fault! "HTTP Error" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   404
   [resp] (ex/ex-not-found! "Not Found" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   403
   [resp] (ex/ex-forbidden! "Forbidden" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   401
   [resp] (ex/ex-forbidden! "Unauthorized" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   400
   [resp] (ex/ex-incorrect! "Bad Request" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   409
   [resp] (ex/ex-conflict! "Conflict" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   405
   [resp] (ex/ex-unsupported! "Method Not Allowed" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   429
   [resp] (ex/ex-busy! "Too Many Requests" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   500
   [resp] (ex/ex-fault! "Internal Server Error" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   501
   [resp] (ex/ex-unsupported! "Not Implemented" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   503
   [resp] (ex/ex-busy! "Service Unavailable" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   502
   [resp] (ex/ex-unavailable! "Bad Gateway" {:response resp}))
 
-(defmethod response->ex-info
+(defmethod response->ex-info!
   504
   [resp] (ex/ex-unavailable! "Gateway Timeout" {:response resp}))
 

--- a/modules/ex-http/test/exoscale/ex/test/http_test.clj
+++ b/modules/ex-http/test/exoscale/ex/test/http_test.clj
@@ -30,13 +30,13 @@
 
 (deftest response->ex-info
   (testing "Should return ex/fault as the default option"
-    (is (thrown-ex-info-type? ::ex/fault (ex-http/response->ex-info {:status :not-mapped}))))
+    (is (thrown-ex-info-type? ::ex/fault (ex-http/response->ex-info! {:status :not-mapped}))))
 
   (testing "Should return ex/not-found for a 404"
-    (is (thrown-ex-info-type? ::ex/not-found (ex-http/response->ex-info {:status 404}))))
+    (is (thrown-ex-info-type? ::ex/not-found (ex-http/response->ex-info! {:status 404}))))
 
   (testing "Should allow overwriting in a consuming namespace"
-    (do (defmethod ex-http/response->ex-info 404 [_] ::overwritten)
+    (do (defmethod ex-http/response->ex-info! 404 [_] ::overwritten)
         (is (= ::overwritten
-               (ex-http/response->ex-info {:status 404}))))))
+               (ex-http/response->ex-info! {:status 404}))))))
 


### PR DESCRIPTION
I realized over the weekend that this function should probably have a bang in the name.

We'll have to make a new release and the change is theoretically breaking, but it is unlikely someone is relying on this already.

If we prefer to leave it as is, that's fine too.