### PR TITLE
Allow :exoscale.ex/type and :type keys

### DIFF
--- a/modules/ex-auspex/test/exoscale/ex/test/auspex_test.clj
+++ b/modules/ex-auspex/test/exoscale/ex/test/auspex_test.clj
@@ -9,7 +9,7 @@
 (clojure.spec.test.alpha/instrument)
 
 (deftest test-auspex
-  (let [ex (ex-info "bar" {:type ::bar1 :bar :baz})]
+  (let [ex (ex-info "bar" {::ex/type ::bar1 :bar :baz})]
     (is (= ::boom
            @(-> (a/error-future ex)
                 (c/catch ::bar1

--- a/modules/ex-manifold/test/exoscale/ex/test/manifold_test.clj
+++ b/modules/ex-manifold/test/exoscale/ex/test/manifold_test.clj
@@ -10,19 +10,19 @@
 
 (deftest test-manifold
   (is (= ::boom
-         @(-> (d/error-deferred (ex-info "bar" {:type ::bar1 :bar :baz}))
+         @(-> (d/error-deferred (ex-info "bar" {::ex/type ::bar1 :bar :baz}))
               (m/catch ::bar1
                        (fn [d] ::boom)))))
 
   (ex/derive ::bar1 ::baz1)
   (is (= ::boom
-         @(-> (d/error-deferred (ex-info "bar" {:type ::bar1 :bar :baz}))
+         @(-> (d/error-deferred (ex-info "bar" {::ex/type ::bar1 :bar :baz}))
               (m/catch ::baz1
                        (fn [d] ::boom)))))
   (ex/underive ::bar1 ::baz1)
 
   (is (thrown? clojure.lang.ExceptionInfo
-               @(-> (d/error-deferred (ex-info "bar" {:type ::bar1 :bar :baz}))
+               @(-> (d/error-deferred (ex-info "bar" {::ex/type ::bar1 :bar :baz}))
                     (m/catch ::bak1
                              (fn [d] ::boom)))))
   (is (= :foo
@@ -33,7 +33,7 @@
 (deftest test-collisions
   (testing "make sure manifold catch is not interpreted as try+/catch"
     (is (= 1 (ex/try+
-              (m/catch (d/error-deferred (ex-info "foo" {:type :bar}))
+              (m/catch (d/error-deferred (ex-info "foo" {::ex/type :bar}))
                        :foo
                 (fn [& args] nil))
               1

--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -1,6 +1,6 @@
 (ns exoscale.ex
   (:refer-clojure :exclude [ex-info derive underive ancestors descendants
-                            parents isa? set-validator!])
+                            parents isa? set-validator! type])
   (:require [clojure.spec.alpha :as s]
             [clojure.core.specs.alpha :as cs]
             [clojure.string :as str]
@@ -55,12 +55,30 @@
   [child parent]
   (clojure.core/isa? @hierarchy child parent))
 
-(defmulti ^:no-doc ex-data-spec :type)
-(defmethod ex-data-spec :default [_] (s/keys :opt-un [::type]))
+(s/fdef type
+  :args (s/cat :ex-data (s/nilable map?)))
+(defn type
+  [d]
+  (or (::type d)
+      ;; backward compatibility
+      (:type d)))
+
+(s/fdef ex-type
+  :args (s/cat :ex ::exception))
+(defn ex-type
+  [ex]
+  (type (ex-data ex)))
+
+(defmulti ^:no-doc ex-data-spec type)
+(defmethod ex-data-spec :default [_]
+  (s/keys
+   :opt [::type]
+   ;; backward compat
+   :opt-un [::type]))
 
 (s/def ::message string?)
 (s/def ::type qualified-keyword?)
-(s/def ::ex-data (s/multi-spec ex-data-spec :type))
+(s/def ::ex-data (s/multi-spec ex-data-spec ::type))
 (s/def ::exception #(instance? Exception %))
 
 (s/fdef set-ex-data-spec!
@@ -117,7 +135,7 @@
 (defn type?
   "Returns true if `ex` is an ex-info with descendant/type of `type`"
   [ex t]
-  (some-> ex ex-data :type (isa? t)))
+  (some-> ex ex-type (isa? t)))
 
 (s/fdef catch*
   :args (s/cat :exception ::exception
@@ -167,11 +185,12 @@
   "Like try but with support for ex-info/ex-data.
 
   If you pass a `catch-data` form it will try to match an
-  ex-info :type key, or it's potential ancestors in the local hierarchy.
+  ex-info :exoscale.ex/type key (or just :type), or it's potential
+  ancestors in the local hierarchy.
 
   ex-info clauses are checked first, in the order they were specified.
-  catch-data will take as arguments a :type key, and a binding for
-  the ex-data of the ex-info instance.
+  catch-data will take as arguments a type key, and a binding for the
+  ex-data of the ex-info instance.
 
   (try
     [...]
@@ -201,7 +220,7 @@
            (seq catch-data-clauses)
            (conj `(catch clojure.lang.ExceptionInfo ~ex-sym
                     (let [~data-sym (ex-data ~ex-sym)
-                          ~type-sym (:type ~data-sym)]
+                          ~type-sym (type ~data-sym)]
                       (cond
                         ~@(mapcat (fn [[_ type binding & body]]
                                     `[(isa? ~type-sym ~type)
@@ -243,7 +262,9 @@
                  coll-type?
                  first)
          deriving (when coll-type? (second type))
-         data' (assoc data :type type')]
+         data' (assoc data
+                      :type type' ; backward compatibility
+                      ::type type')]
      (assert-ex-data-valid data')
      (run! #(derive type' %) deriving)
      (clojure.core/ex-info msg
@@ -335,7 +356,7 @@
               deriving (parents type)]
           (cond-> {::type type
                    ::message (ex-message x)
-                   ::data (dissoc data :type)}
+                   ::data (dissoc data :type ::type)}
             (seq deriving)
             (assoc ::deriving deriving)
             (some? cause)

--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -350,11 +350,11 @@
 (extend-protocol p/Datafiable
   clojure.lang.ExceptionInfo
   (datafy [x]
-    (let [{:keys [type] :as data} (ex-data x)]
-      (if type
+    (let [data (ex-data x)]
+      (if-let [t (type data)]
         (let [cause (ex-cause x)
-              deriving (parents type)]
-          (cond-> {::type type
+              deriving (parents t)]
+          (cond-> {::type t
                    ::message (ex-message x)
                    ::data (dissoc data :type ::type)}
             (seq deriving)

--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -363,6 +363,11 @@
             (assoc ::cause (p/datafy cause))))
         (Throwable->map x)))))
 
+(defn datafy
+  "Convenience function to call datafy on a potential exception"
+  [ex]
+  (p/datafy ex))
+
 (s/fdef map->ex-info
   :args (s/cat :ex-map ::ex-map
                :options (s/? (s/keys :opt [::derive?]))))

--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -58,6 +58,8 @@
 (s/fdef type
   :args (s/cat :ex-data (s/nilable map?)))
 (defn type
+  "Returns `type` value from ex-data map (not the ex-info instance, use
+  `ex-type` for this"
   [d]
   (or (::type d)
       ;; backward compatibility
@@ -66,6 +68,7 @@
 (s/fdef ex-type
   :args (s/cat :ex ::exception))
 (defn ex-type
+  "Returns the `type` of the ex-info if possible"
   [ex]
   (type (ex-data ex)))
 

--- a/modules/ex/test/exoscale/ex/test/core_test.clj
+++ b/modules/ex/test/exoscale/ex/test/core_test.clj
@@ -150,6 +150,7 @@
                        {:a 1}
                        (ex/ex-incorrect "the-cause"))]
     (is (= (p/datafy x)
+           (ex/datafy x)
            #:exoscale.ex{:exoscale.ex/type ::datafy
                          :message "boom"
                          :data {:a 1}

--- a/modules/ex/test/exoscale/ex/test/core_test.clj
+++ b/modules/ex/test/exoscale/ex/test/core_test.clj
@@ -17,12 +17,19 @@
        e#)))
 
 (deftest test-catch
-  (let [d {:type ::foo}]
+  (let [d {:exoscale.ex/type ::foo}]
     (is (= d
            (ex/try+
             (throw (ex-info "asdf" d))
             (catch ::foo x
               x))))
+
+    (is (= d
+           (ex/try+
+            (throw (ex-info "asdf" {:type ::foo}))
+            (catch ::foo x
+              x)))
+        "ensure legacy format works")
 
     (is (true?
          (ex/try+
@@ -31,10 +38,10 @@
             x))))
 
     ;; no match but still ex-info
-    (is (= {:type ::asdf}
+    (is (= {:exoscale.ex/type ::asdf}
            (ex-data (try-val
                      (ex/try+
-                      (throw (ex-info "asdf" {:type ::asdf}))
+                      (throw (ex-info "asdf" {:exoscale.ex/type ::asdf}))
                       (catch ::foo x
                         x))))))
 
@@ -46,15 +53,15 @@
                        x)))))))
 
 (deftest test-catch
-  (let [d {:type ::foo}]
+  (let [d {:exoscale.ex/type ::foo}]
     (is (= d
            (ex/catch (ex-info "asdf" d) ::foo
              identity
              (fn [] ::err))))
 
     ;; no match
-    (is (= {:type ::asdf}
-           (ex-data (ex/catch (ex-info "asdf" {:type ::asdf}) ::foo
+    (is (= {:exoscale.ex/type ::asdf}
+           (ex-data (ex/catch (ex-info "asdf" {:exoscale.ex/type ::asdf}) ::foo
                       (constantly false)
                       identity))))
     (is (instance? Exception
@@ -63,20 +70,20 @@
 
 (deftest test-inheritance
   (ex/derive ::bar ::foo)
-  (let [d {:type ::bar}]
+  (let [d {:exoscale.ex/type ::bar}]
     (is (ex/try+
          (throw (ex-info "" d))
          (catch ::foo ex
            (= ex d)))))
 
   (ex/derive ::baz ::bar)
-  (let [e {:type ::baz}]
+  (let [e {:exoscale.ex/type ::baz}]
     (is (ex/try+
          (throw (ex-info "" e))
          (catch ::foo ex
            (= ex e)))))
 
-  (let [e {:type ::bak}]
+  (let [e {:exoscale.ex/type ::bak}]
     (is (try-val (ex/try+
                   (throw (ex-info "" e))
                   (catch ::foo ex
@@ -84,26 +91,26 @@
 
 (deftest test-bindings
   (is (ex/try+
-       (throw (ex-info "" {:type ::foo
+       (throw (ex-info "" {:exoscale.ex/type ::foo
                            :bar 1}))
        (catch ::foo {:keys [bar]}
          (= bar 1)))))
 
 (deftest special-binding
   (ex/try+
-   (throw (ex-info "" {:type ::foo
+   (throw (ex-info "" {:exoscale.ex/type ::foo
                        :bar 1}))
    (catch ::foo {:as e}
      (let [e &ex]
        (ex/try+
-        (throw (ex-info "" {:type ::bar}))
+        (throw (ex-info "" {:exoscale.ex/type ::bar}))
         (catch ::bar b
           (is (not= &ex e))
           (is (instance? Exception &ex))
           (is (instance? Exception e))))))))
 
 (deftest test-complex-meta
-  (let [x (ex-info "" {:type ::ex-with-meta})]
+  (let [x (ex-info "" {:exoscale.ex/type ::ex-with-meta})]
     (is (ex/try+
          (throw x)
          (catch ::ex-with-meta
@@ -113,12 +120,12 @@
 (deftest test-spec
   (s/def ::foo string?)
   (ex/set-ex-data-spec! ::a1 (s/keys :req [::foo]))
-  (is (false? (s/valid? ::ex/ex-data {:type ::a1})))
-  (is (true? (s/valid? ::ex/ex-data {:type ::a1 ::foo "bar"}))))
+  (is (false? (s/valid? ::ex/ex-data {:exoscale.ex/type ::a1})))
+  (is (true? (s/valid? ::ex/ex-data {:exoscale.ex/type ::a1 ::foo "bar"}))))
 
 (deftest test-within-eval
   (is (= 1 (eval `(do (ex/try+
-                       (throw (ex-info "boom" {:type ::bar}))
+                       (throw (ex-info "boom" {:exoscale.ex/type ::bar}))
                        (catch ::bar e# 1)))))))
 
 (deftest test-thrown-ex-data
@@ -143,11 +150,11 @@
                        {:a 1}
                        (ex/ex-incorrect "the-cause"))]
     (is (= (p/datafy x)
-           #:exoscale.ex{:type ::datafy
+           #:exoscale.ex{:exoscale.ex/type ::datafy
                          :message "boom"
                          :data {:a 1}
                          :deriving #{:exoscale.ex/foo :exoscale.ex/bar}
-                         :cause #:exoscale.ex{:type ::ex/incorrect
+                         :cause #:exoscale.ex{:exoscale.ex/type ::ex/incorrect
                                               :message "the-cause"
                                               :data {}}})
         "test datafy in")


### PR DESCRIPTION
In hindsight I should have only allowed a ns'ed key for :type, this PR makes it possible to supply :type or :exoscale.ex/type. This makes it more symmetrical with the datafy return as well.