### PR TITLE
remove assert ex data valid checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,32 +131,6 @@ of a `catch` block in `try+` but with a more manifold like feel.
     (d/catch (fn [ex] "... regular manifold handling here")))
 ```
 
-### Specing your ex-infos data
-
-You can specify a clojure.spec for the `ex-data` via the multimethod at
-`:exoscale.ex/ex-data-spec` or via the sugar fn provided
-`exoscale.ex/set-ex-data-spec!`:
-
-```clj
-(ex/set-ex-data-spec! ::foo (s/keys :req [...] :opt [...]}))]}))`
-```
-
-By default this is enforced via `clojure.spec/assert`, meaning unless
-you toggled it "on" explicitely, it will be off.
-
-You can change this behavior and set the validator to something else
-like a log statement:
-
-```clj
-(ex/set-validator!
-  (fn [data]
-    (when-not (s/valid? ::ex/ex-data)
-      (log/warnf "ex-data caught doesn't match the spec for it's :type : %s" data))))
-```
-
-It is strongly discouraged to make this validation breaking the flow
-of execution in production as this would only show up at "catch time".
-
 ### How to get to the original exception
 
 You can also get the full exception instance via the metadata on the

--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -92,17 +92,6 @@
   [type spec]
   (defmethod ex-data-spec type [_] spec))
 
-(defn ^:no-doc assert-ex-data-valid
-  "ex-data Validator function"
-  [ex-data]
-  (s/assert ::ex-data ex-data))
-
-#?(:clj
-   (defn set-validator!
-     "Sets validation failure handler globally"
-     [f]
-     (alter-var-root #'assert-ex-data-valid (constantly f))))
-
 (def ^:no-doc catch-sym? #{'catch})
 
 (defn ^:no-doc catch-expr?
@@ -153,7 +142,6 @@
   [e type-key handler continue]
   (if (type? e type-key)
     (let [d (ex-data e)]
-      (assert-ex-data-valid d)
       (handler (data+ex d e)))
     (continue e)))
 
@@ -227,10 +215,8 @@
                       (cond
                         ~@(mapcat (fn [[_ type binding & body]]
                                     `[(isa? ~type-sym ~type)
-                                      (do
-                                        (assert-ex-data-valid ~data-sym)
-                                        (let [~binding (data+ex ~data-sym ~ex-sym)]
-                                          ~@body))])
+                                      (let [~binding (data+ex ~data-sym ~ex-sym)]
+                                        ~@body)])
                                   catch-data-clauses)
                         :else
                         ;; rethrow ex-info with other clauses since we
@@ -268,7 +254,6 @@
          data' (assoc data
                       :type type' ; backward compatibility
                       ::type type')]
-     (assert-ex-data-valid data')
      (run! #(derive type' %) deriving)
      (clojure.core/ex-info msg
                            data'

--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -1,6 +1,6 @@
 (ns exoscale.ex
   (:refer-clojure :exclude [ex-info derive underive ancestors descendants
-                            parents isa? set-validator! type])
+                            parents isa? type])
   (:require [clojure.spec.alpha :as s]
             [clojure.core.specs.alpha :as cs]
             [clojure.string :as str]
@@ -83,14 +83,6 @@
 (s/def ::type qualified-keyword?)
 (s/def ::ex-data (s/multi-spec ex-data-spec ::type))
 (s/def ::exception #(instance? Exception %))
-
-(s/fdef set-ex-data-spec!
-  :args (s/cat :type ::type
-               :spec (s/or :kw qualified-keyword?
-                           :spec-obj s/spec?)))
-(defn set-ex-data-spec!
-  [type spec]
-  (defmethod ex-data-spec type [_] spec))
 
 (def ^:no-doc catch-sym? #{'catch})
 

--- a/modules/ex/test/exoscale/ex/test/core_test.clj
+++ b/modules/ex/test/exoscale/ex/test/core_test.clj
@@ -117,12 +117,6 @@
                 x'
            (-> x' meta ::ex/exception (= x)))))))
 
-(deftest test-spec
-  (s/def ::foo string?)
-  (ex/set-ex-data-spec! ::a1 (s/keys :req [::foo]))
-  (is (false? (s/valid? ::ex/ex-data {:exoscale.ex/type ::a1})))
-  (is (true? (s/valid? ::ex/ex-data {:exoscale.ex/type ::a1 ::foo "bar"}))))
-
 (deftest test-within-eval
   (is (= 1 (eval `(do (ex/try+
                        (throw (ex-info "boom" {:exoscale.ex/type ::bar}))


### PR DESCRIPTION
It's a bit cumbersome to have runtime exceptions potentially toggle another exception cause at ex level because a potential malformed payload passed via ex-data.