### PR TITLE
fix potential to create type leafs with multiple parents

### DIFF
--- a/modules/ex-http/src/clj/exoscale/ex/http.clj
+++ b/modules/ex-http/src/clj/exoscale/ex/http.clj
@@ -1,5 +1,4 @@
-(ns exoscale.ex.http
-  (:require [exoscale.ex :as ex]))
+(ns exoscale.ex.http)
 
 (defmulti response->ex-info!
   "Throws the matching ex exception for status HTTP response.
@@ -8,11 +7,12 @@
 
 (defn- ex!
   [type message data]
-  (throw (ex/ex-info message
-                     [:exoscale.ex.http/response [type]]
-                     (assoc data
-                            ;; backward compat
-                            :response data))))
+  (throw (ex-info message
+                  (assoc data
+                         :exoscale.ex/type type
+                         ;; backward compat
+                         :type type
+                         :response data))))
 
 (defmacro def-response->ex [status type message]
   `(defmethod response->ex-info! ~status

--- a/modules/ex-http/test/exoscale/ex/test/http_test.clj
+++ b/modules/ex-http/test/exoscale/ex/test/http_test.clj
@@ -11,29 +11,26 @@
   (let [k (nth form 1)
         body (nthnext form 2)]
     `(ex/try+
-      ~@body
-      (t/do-report {:type :fail
-                    :message ~msg
-                    :expected '~form
-                    :actual nil})
-      (catch ~k d#
-        (t/do-report {:type :pass
-                      :message ~msg,
-                      :expected '~form
-                      :actual d#})
-        (::ex/exception d#))
-      (catch Exception e#
-        (t/do-report {:type :fail
-                      :message ~msg
-                      :expected '~form
-                      :actual e#})))))
+       ~@body
+       (t/do-report {:type :fail
+                     :message ~msg
+                     :expected '~form
+                     :actual nil})
+       (catch ~k d#
+         (t/do-report {:type :pass
+                       :message ~msg,
+                       :expected '~form
+                       :actual d#})
+         (::ex/exception d#))
+       (catch Exception e#
+         (t/do-report {:type :fail
+                       :message ~msg
+                       :expected '~form
+                       :actual e#})))))
 
 (deftest response->ex-info
   (testing "Should return ex/fault as the default option"
     (is (thrown-ex-info-type? ::ex/fault (ex-http/response->ex-info! {:status :not-mapped}))))
-
-  (is (thrown-ex-info-type? ::ex-http/response (ex-http/response->ex-info! {:status :not-mapped}))
-      "They all derive from top level ::ex-http/response")
 
   (testing "Should return ex/not-found for a 404"
     (is (thrown-ex-info-type? ::ex/not-found (ex-http/response->ex-info! {:status 404}))))

--- a/modules/ex-http/test/exoscale/ex/test/http_test.clj
+++ b/modules/ex-http/test/exoscale/ex/test/http_test.clj
@@ -11,22 +11,22 @@
   (let [k (nth form 1)
         body (nthnext form 2)]
     `(ex/try+
-       ~@body
-       (t/do-report {:type :fail
-                     :message ~msg
-                     :expected '~form
-                     :actual nil})
-       (catch ~k d#
-         (t/do-report {:type :pass
-                       :message ~msg,
-                       :expected '~form
-                       :actual d#})
-         (::ex/exception d#))
-       (catch Exception e#
-         (t/do-report {:type :fail
-                       :message ~msg
-                       :expected '~form
-                       :actual e#})))))
+      ~@body
+      (t/do-report {:type :fail
+                    :message ~msg
+                    :expected '~form
+                    :actual nil})
+      (catch ~k d#
+        (t/do-report {:type :pass
+                      :message ~msg,
+                      :expected '~form
+                      :actual d#})
+        (::ex/exception d#))
+      (catch Exception e#
+        (t/do-report {:type :fail
+                      :message ~msg
+                      :expected '~form
+                      :actual e#})))))
 
 (deftest response->ex-info
   (testing "Should return ex/fault as the default option"

--- a/modules/ex/src/clj/exoscale/ex.cljc
+++ b/modules/ex/src/clj/exoscale/ex.cljc
@@ -1,10 +1,10 @@
 (ns exoscale.ex
   (:refer-clojure :exclude [ex-info derive underive ancestors descendants
                             parents isa? type])
-  (:require [clojure.spec.alpha :as s]
+  (:require [clojure.core.protocols :as p]
             [clojure.core.specs.alpha :as cs]
-            [clojure.string :as str]
-            [clojure.core.protocols :as p]))
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
 
 (defonce hierarchy (atom (make-hierarchy)))
 
@@ -228,7 +228,7 @@
                :data (s/? (s/nilable ::ex-data))
                :cause (s/? (s/nilable ::exception))))
 (s/def ::deriving (s/coll-of ::type))
-(defn ex-info
+(defn ^:deprecated ex-info
   "Like `clojure.core/ex-info` but adds validation of the ex-data,
   automatic setting of the data `:type` from argument and potential
   derivation. You can specify type as either a keyword or a tuple of
@@ -242,6 +242,7 @@
          type' (cond-> type
                  coll-type?
                  first)
+         ;; TODO depreciate this, we shouldn't do auto-derivation here
          deriving (when coll-type? (second type))
          data' (assoc data
                       :type type' ; backward compatibility


### PR DESCRIPTION
* also depreciate ex/ex-info in favor of explicit derivation (less prone to bugs)

That causes problems when stuff like ex->format tries to find what to match a exoscale.ex.http/response since it would have multiple parents of our canonical types.